### PR TITLE
Add API lookup method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,60 @@
 itunes-node
 ===========
 
-search against iTunes using nodejs
+Search against iTunes using nodejs.
 
-## installation
+## Installation
 
 ```js
 npm install itunes-search
 ```
 
-## example
+## Search
+
+[API Search reference](http://www.apple.com/itunes/affiliates/resources/documentation/itunes-store-web-service-search-api.html#searching)
 
 ```js
+var itunes = require('itunes-search');
 
-var itunes = require('itunes-search')
-
-// http://www.apple.com/itunes/affiliates/resources/documentation/itunes-store-web-service-search-api.html#searching
-// options example:
-// options = {
-//    media: "movie" // options are: podcast, music, musicVideo, audiobook, shortFilm, tvShow, software, ebook, all
-//  , entity: "movie"
-//  , attribute: "movie"
-//  , limit: 50
-//  , explicit: "No" // explicit material
-// }
 var options = {
-    media: "movie"
-  , entity: "movie"
-  , limit: 25
-}
+	 term: "field of dreams"
+ , media: "movie" // options are: podcast, music, musicVideo, audiobook, shortFilm, tvShow, software, ebook, all
+ , entity: "movie"
+ , attribute: "movieTerm"
+ , limit: 50
+ , explicit: "No" // explicit material
+ , country: "CA" // default US
+};
 
-itunes.search( "field of dreams", options, function(response) {
-  // do stuff with 'response'
-})
+itunes.search(options, function(err, response) {
+	if (err) {
+		console.log(err);
+	} else {
+		console.log(response);
+	}  
+});
+```
 
+## Lookup
+
+[API Lookup reference](http://www.apple.com/itunes/affiliates/resources/documentation/itunes-store-web-service-search-api.html#lookup)
+
+```js
+var itunes = require('itunes-search');
+
+var options = {
+   id: 481473944
+ , entity: "album"
+ , limit: 25
+ , sort: "recent"
+ , country: "CA" // default US
+};
+
+itunes.lookup(options, function(err, response) {
+	if (err) {
+		console.log(err);
+	} else {
+		console.log(response);
+	}  
+});
 ```

--- a/examples/lookup.js
+++ b/examples/lookup.js
@@ -1,0 +1,17 @@
+var itunes = require('../lib/itunes');
+
+var options = {
+   id: 481473944
+ , entity: "album"
+ , limit: 25
+ , sort: "recent"
+ , country: "CA" // default US
+};
+
+itunes.lookup(options, function(err, response) {
+	if (err) {
+		console.log(err);
+	} else {
+		console.log(response);
+	}  
+});

--- a/examples/search.js
+++ b/examples/search.js
@@ -1,0 +1,19 @@
+var itunes = require('../lib/itunes');
+
+var options = {
+	 term: "field of dreams"
+ , media: "movie" // options are: podcast, music, musicVideo, audiobook, shortFilm, tvShow, software, ebook, all
+ , entity: "movie"
+ , attribute: "movieTerm"
+ , limit: 50
+ , explicit: "No" // explicit material
+ , country: "CA" // default US
+};
+
+itunes.search(options, function(err, response) {
+	if (err) {
+		console.log(err);
+	} else {
+		console.log(response);
+	}  
+});

--- a/lib/itunes.js
+++ b/lib/itunes.js
@@ -1,25 +1,86 @@
-var request = require('request')
+var request = require('request');
 
-exports.search = function(query, options, callback) {
 
-  // http://www.apple.com/itunes/affiliates/resources/documentation/itunes-store-web-service-search-api.html#searching
-  // options example:
-  // options = {
-  //    media: "movie" // options are: podcast, music, musicVideo, audiobook, shortFilm, tvShow, software, ebook, all
-  //  , entity: "movie"
-  //  , attribute: "movie"
-  //  , limit: 50
-  //  , explicit: "No" // explicit material
-  // }
+function setDefaultOptions(options, defaultOptions) {
 
-  var optionsString = "";
-
-  for (item in options) {
-    optionsString += "&" + item + "=" + encodeURIComponent(options[item]);
+  for (item in defaultOptions) {
+    if (!options.hasOwnProperty(item)) {
+      options[item] = defaultOptions[item];
+    }
   }
-
-  request("http://itunes.apple.com/search?country=us" + optionsString + "&term=" + encodeURIComponent(query), function(err, response, body) {
-    callback( JSON.parse(body) )
-  })
-
+  return options;
 }
+
+
+function generateURL(baseURL, options, defaultOptions) {
+
+  options = setDefaultOptions(options, defaultOptions);
+
+  var optionsString = Object.keys(options).map(function(item) {
+    return item + "=" + encodeURIComponent(options[item])
+  }).join("&");
+
+  // iTunes uses application/x-www-form-urlencoded
+  // so we replace space "%20" with "+"
+  optionsString = optionsString.replace(/%20/g, "+");
+    
+  return baseURL + optionsString;
+}
+
+
+function makeRequest (url, callback) {
+
+  request(url, function(err, response, body) {
+    if (err) {
+      callback(err, null);    
+    } else if (response.statusCode !== 200) {
+      callback("Bad response from iTunes server", null);
+    } else {
+      callback(null, JSON.parse(body));
+    }
+  });  
+}
+
+
+/**
+http://www.apple.com/itunes/affiliates/resources/documentation/itunes-store-web-service-search-api.html#searching
+options example:
+options = {
+   term: "field of dreams"
+ , media: "movie" // options are: podcast, music, musicVideo, audiobook, shortFilm, tvShow, software, ebook, all
+ , entity: "movie"
+ , attribute: "movieTerm"
+ , limit: 50
+ , explicit: "No" // explicit material
+ , country: "CA" // default US
+};
+*/
+exports.search = function(options, callback) {
+
+  var url = generateURL("http://itunes.apple.com/search?", options, {
+    country: "US"
+  });
+  console.log(url);
+  makeRequest(url, callback);
+};
+
+
+/**
+http://www.apple.com/itunes/affiliates/resources/documentation/itunes-store-web-service-search-api.html#lookup
+options example:
+options = {
+   id: 481473944
+ , entity: "album"
+ , limit: 25
+ , sort: "recent"
+ , country: "CA" // default US
+};
+*/
+exports.lookup = function(options, callback) {
+
+  var url = generateURL("http://itunes.apple.com/lookup?", options, {
+    country: "US"
+  });
+
+  makeRequest(url, callback);
+};


### PR DESCRIPTION
Add [API lookup method](http://www.apple.com/itunes/affiliates/resources/documentation/itunes-store-web-service-search-api.html#lookup) as suggested in issue #2
- refactoring:
   - search function, the 'term' param is now options
   - method can have a 'country' option
   - methods’ callback takes 2 params (err, response)
- also add examples